### PR TITLE
Move tournament into SaveData.register

### DIFF
--- a/Plugins/Chasm Save Conversions/3.4/FixTournament.rb
+++ b/Plugins/Chasm Save Conversions/3.4/FixTournament.rb
@@ -1,8 +1,0 @@
-SaveData.register_conversion(:tournament_340) do
-  game_version '3.4.0'
-  display_title 'Updating saved Tournament data for 3.4.0 changes'
-  to_all do |save_data|
-    # TODO: When Tournament is moved out of GlobalMetadata, this will be in the same conversion to avoid conflicts
-    save_data[:global_metadata].tournament.updateTrainerTypes()
-  end
-end

--- a/Plugins/Tectonic Content Scripts/Tournament.rb
+++ b/Plugins/Tectonic Content Scripts/Tournament.rb
@@ -144,21 +144,6 @@ class RandomTournament
         flags.push("cursed") if @cursed_wins == FINAL_ROUND
         teamSnapshot("Makyan Champion", flags)
     end
-
-    # Save conversion helper function
-    def updateTrainerTypes
-        for match in @matches
-            trainerType = match[0].to_s
-            if trainerType.start_with?("LEADER_") && trainerType.end_with?("_2")
-                newTrainerType = trainerType[0..-3].to_sym
-                if GameData::TrainerType.exists?(newTrainerType)
-                    match[0] = newTrainerType
-                else
-                    echoln("Warning: Unable to find updated TrainerType #{newTrainerType} for #{trainerType}")
-                end
-            end
-        end
-    end
 end
 
 def tournamentBattle()


### PR DESCRIPTION
This moves it out of GlobalMetadata, which was causing issues on Engine.

Currently this approach leverages the fact that the tournament automatically gets initialised anew to help deal with the save conversion issues with the previous change to TrainerTypes. This means a save that updates will have their tournament lineup re-rolled, but they'll only notice if they update in the middle of the tournament, which seems minimally disruptive. Still, feel free to reject and request a more thorough approach.

Currently, the Metadata initialisation still creates an extra tournament that goes unused. Removing this will be an Engine PR, and with this merged that should no longer interfere with Tectonic. 