### PR TITLE
Add save conversion to instantiate $Trainer.policies if missing

### DIFF
--- a/Plugins/Chasm Save Conversions/3.4/MissingTrainerData.rb
+++ b/Plugins/Chasm Save Conversions/3.4/MissingTrainerData.rb
@@ -1,0 +1,7 @@
+SaveData.register_conversion(:missing_trainer_policies) do
+  game_version '3.4.0'
+  display_title 'Fixing missing trainer data.'
+  to_all do |save_data|
+    save_data[:player].policies = [] if save_data[:player].policies.nil?
+  end
+end


### PR DESCRIPTION
Fix #148

I'm not 100% sure this is correct and I'm not sure how to easily test save conversions, but I referenced the 2.0 conversion