### PR TITLE
Allow manual trigger of server update workflow

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -5,7 +5,7 @@ on:
         types: [closed]
         branches:
             - main
-
+    workflow_dispatch:
 jobs:
     deploy:
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
To account for cases where changes have been merged in from Engine without a PR on content

Gonna self-approve this immediately, just making it a PR so that - ironically - it automatically updates afterwards.
No need to merge into main-3.4, this is only github-side infrastructure.