### PR TITLE
Update credits

### DIFF
--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -22,14 +22,16 @@ envygender<s>Errata
 Eseria<s>IgnitedxSoul
 Lilypad<s>Miss Zesty
 oddium wanderus<s>Pria
-Riptidecord<s>Steeb
-TikiShades<s>Tirankin
+Riptidecord<s>ShadowKirbae
+Steeb<s>TikiShades
+Tirankin
 
 Technical Design
 Zinnia<s>Agentbla
 Brickbat<s>Emmi
 envygender<s>Lilypad
-Riptidecord<s>ValourDyke
+Riptidecord<s>ShadowKirbae
+ValourDyke
 
 Programming
 Zinnia<s>LunaFlare

--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -63,10 +63,10 @@ Lilypad<s>Splitmoon
 TikiShades<s>ValourDyke
 
 Publicity
-Emmi<s>IgnitedxSoul
-Lilypad<s>Mary
-Pepper<s>Pria
-Valrex
+Atteathesilly<s>Emmi
+IgnitedxSoul<s>Lilypad
+Mary<s>Pepper
+Pria<s>Valrex
 
 Translation
 Fanfan<s>Valrex

--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -31,7 +31,6 @@ Zinnia<s>Agentbla
 Brickbat<s>Emmi
 envygender<s>Lilypad
 Riptidecord<s>ShadowKirbae
-ValourDyke
 
 Programming
 Zinnia<s>LunaFlare

--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -1,37 +1,86 @@
 CHASM_CREDITs = <<_END_
 
-Major Contributors
-Brickbat<s>Zinnia
-Divock<s>Agentbla
-Wakarimasensei<s>Drawingbox
-IgnitedxSoul<s>LucaSantosSims
-Darlvon<s>Jaggedthorn
-Splitmoon<s>TikiShades
-Valrex<s>Steeb
-Tirankin<s>Ci
-Yufeng<s>Riptidecord
-LunaFlare
+Leadership
+Zinnia<s>jessica gaylord
+LunaFlare<s>Riptidecord
+ShadowKirbae
+
+Past Leadership
+Agentbla<s>Brickbat
+Darlvon<s>Drawingbox
+LucaSantosSims<s>Pria
+Steeb<s>Valrex
+Wakarimasensei
+
+Design
+Zinnia<s>jessica gaylord
+Atteathesilly<s>Aurora
+Azeler<s>Bella
+Chus<s>Darlvon
+Emmi<s>EnterSP
+envygender<s>Errata
+Eseria<s>IgnitedxSoul
+Lilypad<s>oddium wanderus
+Pria<s>Steeb
+TikiShades<s>Tirankin
+ZombyGoast
+
+Technical Design
+Zinnia<s>Agentbla
+Brickbat<s>Emmi
+envygender<s>Lilypad
+Riptidecord<s>ValourDyke
+
+Programming
+Zinnia<s>LunaFlare
+Ardub<s>Azeler
+Darlvon<s>Eseria
+JBSundown<s>ShadowKirbae
+
+Writing
+Zinnia<s>elusivestowaway
+Errata<s>Nora
+ValourDyke<s>Wakarimasensei
+
+Art
+Atteathesilly<s>Destinygreatness
+Drawingbox<s>Jaggedthorn
+lichenprincess<s>Lodestar195
+M1ntyFr3shD4n<s>Manycrows
+noodleman<s>papper
+Pechapanda<s>ZombyGoast
+
+Music
+LucaSantosSims<s>LunaFlare
+Pria<s>Zufaix
+
+Quality Assurance
+ShadowKirbae<s>Chus
+EnterSP<s>envygender
+Errata<s>Splitmoon
+TikiShades<s>ValourDyke
+
+Publicity
+IgnitedxSoul<s>Mary
+Pepper<s>Pria
+
+Translation
+Fanfan<s>Valrex
+Yufeng
 
 Other Contributors
-Arenastellez<s>Zufaix
-Fbarbarosa<s>ctWizard
-Slaynoir<s>Maddie
-FurretKnight<s>Dtp81390
-Gabs<s>derrondad
+Arenastellez<s>Badman
 BlueObelisk<s>SimplyDark
 MrPanda1<s>Angelcake
-Mikomii<s>Jbsundown
-Valrex<s>Avery
-Destinygreatness<s>Gary Oak
-ali760<s>papper
-lichenprincess<s>Enigma
+Mikomii<s>Gary Oak
+ali760<s>Enigma
 princessroxie<s>Joaquín Arellano
-M1ntyFr3shD4n<s>pechapanda
-zombygoast<s>elusivestowaway
-Kei<s>Atteathesilly
-noodleman<s>Manycrows
-Eseria<s>Reinhart Menken
-Badman<s>
+Kei<s>Reinhart Menken
+Ci<s>ctWizard
+derrondad<s>Dtp81390
+Fbarbarosa<s>FurretKnight
+Gabs<s>Maddie
+Slaynoir
 
 {INSERTS_PLUGIN_CREDITS_DO_NOT_REMOVE}
 

--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -57,13 +57,16 @@ Pria<s>Zufaix
 
 Quality Assurance
 ShadowKirbae<s>Chus
-EnterSP<s>envygender
-Errata<s>Splitmoon
+Emmi<s>EnterSP
+envygender<s>Errata
+Lilypad<s>Splitmoon
 TikiShades<s>ValourDyke
 
 Publicity
-IgnitedxSoul<s>Mary
+Emmi<s>IgnitedxSoul
+Lilypad<s>Mary
 Pepper<s>Pria
+Valrex
 
 Translation
 Fanfan<s>Valrex

--- a/Plugins/Chasm Graphics and UI/Menus/Credits.rb
+++ b/Plugins/Chasm Graphics and UI/Menus/Credits.rb
@@ -20,10 +20,10 @@ Chus<s>Darlvon
 Emmi<s>EnterSP
 envygender<s>Errata
 Eseria<s>IgnitedxSoul
-Lilypad<s>oddium wanderus
-Pria<s>Steeb
+Lilypad<s>Miss Zesty
+oddium wanderus<s>Pria
+Riptidecord<s>Steeb
 TikiShades<s>Tirankin
-ZombyGoast
 
 Technical Design
 Zinnia<s>Agentbla
@@ -43,12 +43,12 @@ Errata<s>Nora
 ValourDyke<s>Wakarimasensei
 
 Art
-Atteathesilly<s>Destinygreatness
+Atteathesilly<s>DestinyGreatness
 Drawingbox<s>Jaggedthorn
 lichenprincess<s>Lodestar195
 M1ntyFr3shD4n<s>Manycrows
-noodleman<s>papper
-Pechapanda<s>ZombyGoast
+Miss Zesty<s>noodleman
+papper<s>Pechapanda
 
 Music
 LucaSantosSims<s>LunaFlare


### PR DESCRIPTION
Add new contributors for 3.4, arrange by role
Ordering is Zinnia, then relevant team leader, then alphabetical