### PR TITLE
Fixed the Tarot amulet appearing as the inactive

### DIFF
--- a/PBS/items.txt
+++ b/PBS/items.txt
@@ -2699,6 +2699,15 @@ FieldUse = Direct
 Flags = KeyItem
 Description = If reversed, gym leaders and story fights will become harder through unique curses.
 #-------------------------------
+[TAROTAMULET_ACTIVE]
+Name = Tarot Amulet
+NamePlural = Tarot Amulets
+Pocket = 7
+Price = 0
+FieldUse = Direct
+Flags = KeyItem
+Description = If reversed, gym leaders and story fights will become harder through unique curses.
+#-------------------------------
 [NOISEMACHINE]
 Name = Noise Machine
 NamePlural = Noise Machines

--- a/Plugins/Chasm Battle/AI/Trainers AI/Curses/CurseEvents.rb
+++ b/Plugins/Chasm Battle/AI/Trainers AI/Curses/CurseEvents.rb
@@ -86,7 +86,7 @@ class PokeBattle_Battle
 
     def amuletActivates(curseName, explanation = nil)
         echoln("Amulet actives!")
-        pbDisplaySlower(_INTL("\\i[TAROTAMULET]The Tarot Amulet glows with power!"))
+        pbDisplaySlower(_INTL("\\i[TAROTAMULET_ACTIVE]The Tarot Amulet glows with power!"))
 
         curseBG = scene.pbAddSprite("curseBG",0,0,"Graphics/Pictures/Battle/cursebg",@viewport)
         curseBG.visible = true


### PR DESCRIPTION
version during the cursetext in-battle.
TODO: Change the overworld cutscenes showing the correct amulet. Fixes #167